### PR TITLE
Fix typo in main. Fixes webpack failing to load the module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "keywords": [
     "backbone",
+    "browserStorage",
     "localStorage",
     "local",
     "sessionStorage",
@@ -26,7 +27,7 @@
     "cache",
     "sync"
   ],
-  "main": "./backbone.sessionStorage.js",
+  "main": "./backbone.browserStorage.js",
   "engines": {
     "node": "*"
   }


### PR DESCRIPTION
Without this fix you get an error using webpack as it looks for sessionStorage instead of browserStorage. 

>   looking for modules in /home/vagrant/workspace/src/apps/chat/static/conversejs
>     resolve 'directory' backbone.browserStorage in /home/vagrant/workspace/src/apps/chat/static/conversejs/components
> .....
> /home/vagrant/workspace/src/apps/chat/static/conversejs/components/backbone.browserStorage/backbone.sessionStorage.js
